### PR TITLE
Add support for tags and policy_tier inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ No modules.
 | <a name="input_s3_state_file_url"></a> [s3\_state\_file\_url](#input\_s3\_state\_file\_url) | An URL to s3-backend Terraform state-file | `string` | n/a | yes |
 | <a name="input_cross_account_role_arns"></a> [cross\_account\_role\_arns](#input\_cross\_account\_role\_arns) | The list of IAM Role ARNs to be used for querying purposes in other AWS accounts while importing resources and assessing your appliaction | `list(string)` | `[]` | no |
 | <a name="input_invoker_role_name"></a> [invoker\_role\_name](#input\_invoker\_role\_name) | The IAM role name that will be used by AWS Resilience Hub for read-only access to the application resources while running an assessment | `string` | `null` | no |
+| <a name="input_policy_tier"></a> [policy\_tier](#input\_policy\_tier) | The tier for the resiliency policy, ranging from the highest severity (`MissionCritial`) to lowest (`NonCritical`) | `string` | `"MissionCritical"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be assigned to the resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -90,11 +90,13 @@ resource "awscc_resiliencehub_app" "app" {
     cross_account_role_arns = var.cross_account_role_arns
     invoker_role_name       = var.invoker_role_name
   }
+
+  tags = var.tags
 }
 
 resource "awscc_resiliencehub_resiliency_policy" "policy" {
   policy_name = "Policy-${random_id.session.id}"
-  tier        = "MissionCritical"
+  tier        = var.policy_tier
   policy = {
     AZ = {
       rto_in_secs = var.rto
@@ -113,4 +115,6 @@ resource "awscc_resiliencehub_resiliency_policy" "policy" {
       rpo_in_secs = var.rpo
     }
   }
+
+  tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,20 @@ variable "cross_account_role_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "policy_tier" {
+  description = "The tier for the resiliency policy, ranging from the highest severity (`MissionCritial`) to lowest (`NonCritical`)"
+  type        = string
+  default     = "MissionCritical"
+
+  validation {
+    condition     = try(index(["MissionCritical", "Critical", "Important", "CoreServices", "NonCritical", "NotApplicable"], var.policy_tier), -1) != -1
+    error_message = "The policy_tier must be on of MissionCritical | Critical | Important | CoreServices | NonCritical | NotApplicable"
+  }
+
+}
+variable "tags" {
+  description = "Tags to be assigned to the resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Support for tags ensures that we can apply cost allocation tags to the relevant resources

The policy_tier input allows for designation of the severity to be used for a given policy with a default value of `MissionCritical`