### PR TITLE
FIX: Sanity checks for permissions_model input

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_components"></a> [app\_components](#input\_app\_components) | The application's app-components, including its resources | <pre>list(object({<br>    app_component_name = string<br>    app_component_type = string<br>    resources = list(object({<br>      resource_name            = string<br>      resource_type            = string<br>      resource_identifier      = string<br>      resource_identifier_type = string<br>      resource_region          = string<br>    }))<br>  }))</pre> | n/a | yes |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The Application's name | `string` | n/a | yes |
-| <a name="input_permission_type"></a> [permission\_type](#input\_permission\_type) | How AWS Resilience Hub should scan the resources. Either `LegacyIAMUser` or `RoleBased` | `string` | n/a | yes |
 | <a name="input_rpo"></a> [rpo](#input\_rpo) | RPO across all failure metrics | `number` | n/a | yes |
 | <a name="input_rto"></a> [rto](#input\_rto) | RTO across all failure metrics | `number` | n/a | yes |
 | <a name="input_s3_state_file_url"></a> [s3\_state\_file\_url](#input\_s3\_state\_file\_url) | An URL to s3-backend Terraform state-file | `string` | n/a | yes |
 | <a name="input_cross_account_role_arns"></a> [cross\_account\_role\_arns](#input\_cross\_account\_role\_arns) | The list of IAM Role ARNs to be used for querying purposes in other AWS accounts while importing resources and assessing your appliaction | `list(string)` | `[]` | no |
 | <a name="input_invoker_role_name"></a> [invoker\_role\_name](#input\_invoker\_role\_name) | The IAM role name that will be used by AWS Resilience Hub for read-only access to the application resources while running an assessment | `string` | `null` | no |
+| <a name="input_permission_type"></a> [permission\_type](#input\_permission\_type) | How AWS Resilience Hub should scan the resources. Either `LegacyIAMUser` or `RoleBased` | `string` | `null` | no |
 | <a name="input_policy_tier"></a> [policy\_tier](#input\_policy\_tier) | The tier for the resiliency policy, ranging from the highest severity (`MissionCritial`) to lowest (`NonCritical`) | `string` | `"MissionCritical"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be assigned to the resources | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,9 @@ locals {
       name = resource["resource_name"]
     }
   ]
+
+  create_permission_model = var.permission_type != null && (var.invoker_role_name != null || var.cross_account_role_arns != null)
+  permission_model        = local.create_permission_model ? { type = var.permission_type, invoker_role_name = var.invoker_role_name, cross_account_role_arns = var.cross_account_role_arns } : null
 }
 
 resource "random_id" "session" {
@@ -85,11 +88,7 @@ resource "awscc_resiliencehub_app" "app" {
   })
   resource_mappings     = local.resource_mappings
   resiliency_policy_arn = awscc_resiliencehub_resiliency_policy.policy.policy_arn
-  permission_model = {
-    type                    = var.permission_type
-    cross_account_role_arns = var.cross_account_role_arns
-    invoker_role_name       = var.invoker_role_name
-  }
+  permission_model      = local.permission_model
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,7 @@ variable "rpo" {
 variable "permission_type" {
   description = "How AWS Resilience Hub should scan the resources. Either `LegacyIAMUser` or `RoleBased`"
   type        = string
+  default     = null
 }
 
 variable "invoker_role_name" {
@@ -57,7 +58,7 @@ variable "policy_tier" {
 
   validation {
     condition     = try(index(["MissionCritical", "Critical", "Important", "CoreServices", "NonCritical", "NotApplicable"], var.policy_tier), -1) != -1
-    error_message = "The policy_tier must be on of MissionCritical | Critical | Important | CoreServices | NonCritical | NotApplicable"
+    error_message = "The policy_tier must be one of MissionCritical | Critical | Important | CoreServices | NonCritical | NotApplicable"
   }
 
 }


### PR DESCRIPTION
When no invoker role name is specificied, pass `null` value to the `permission_model` argument. Otherwise, the API will return an error

I have also fixed a typo in the validation error message for the `policy_tier` input